### PR TITLE
refactor: load .monkey context at runtime

### DIFF
--- a/lib/commands/install.js
+++ b/lib/commands/install.js
@@ -25,7 +25,7 @@ async function install(options = {}) {
 
   const templatesDir = path.join(__dirname, '../../templates');
   
-  // Load project context for template injection
+  // Load template data (currently just version)
   const context = loadProjectContext();
 
   try {

--- a/lib/utils/files.js
+++ b/lib/utils/files.js
@@ -46,33 +46,14 @@ async function remove(filePath) {
 }
 
 /**
- * Load project context from .monkey files
- * @returns {Object} Object with context data for templates
+ * Load template metadata
+ * @returns {Object} Data available to templates
  */
 function loadProjectContext() {
-  const stackPath = '.monkey/stack.md';
-  const rulesPath = '.monkey/rules.md';
   const packageJson = require('../../package.json');
-  
-  let stackInfo = '';
-  let projectRules = '';
-  
-  if (exists(stackPath)) {
-    stackInfo = fs.readFileSync(stackPath, 'utf8').trim();
-  }
-  
-  if (exists(rulesPath)) {
-    projectRules = fs.readFileSync(rulesPath, 'utf8').trim();
-  }
-  
+
   return {
-    version: packageJson.version,
-    stackInfo,
-    projectRules,
-    hasStack: !!stackInfo,
-    hasRules: !!projectRules,
-    noStack: !stackInfo,
-    noRules: !projectRules
+    version: packageJson.version
   };
 }
 

--- a/templates/agents/planner.md
+++ b/templates/agents/planner.md
@@ -8,32 +8,17 @@ tools: Read, Glob, Grep
 
 You are an experienced technical architect and project planner specializing in breaking down complex software engineering tasks into actionable, low-risk implementation steps for this project.
 
-{{#hasStack}}
 ## Project Technology Stack
 
-{{{stackInfo}}}
+@.monkey/stack.md
 
-Consider these technologies when evaluating implementation options, dependencies, and technical constraints.
+*If this file is missing, recommend running `/stack-scan` to capture technology details.*
 
-{{/hasStack}}
-{{#hasRules}}
 ## Project Development Rules
 
-{{{projectRules}}}
+@.monkey/rules.md
 
-Ensure your implementation plan respects these project boundaries, conventions, and requirements.
-
-{{/hasRules}}
-{{#noStack}}
-## Project Context
-
-*(No stack information available - recommend running `/stack-scan` first to understand technical constraints and available tooling)*
-
-{{/noStack}}
-{{#noRules}}
-*(No project-specific rules defined - consider gathering development standards and constraints during planning process)*
-
-{{/noRules}}
+*If this file is missing, note that no project-specific rules are defined.*
 
 ## Your Mission
 

--- a/templates/agents/reviewer.md
+++ b/templates/agents/reviewer.md
@@ -8,30 +8,17 @@ tools: Read, Glob, Grep, Bash(git:*)
 
 You are a senior software engineer conducting a thorough code review for this project. Your expertise spans multiple languages and frameworks, with deep knowledge of software design patterns, security, and performance optimization.
 
-{{#hasStack}}
 ## Project Technology Stack
 
-{{{stackInfo}}}
+@.monkey/stack.md
 
-{{/hasStack}}
-{{#hasRules}}
 ## Project Development Rules
 
-{{{projectRules}}}
+@.monkey/rules.md
 
 Use these rules to guide your review recommendations and ensure consistency with project standards.
 
-{{/hasRules}}
-{{#noStack}}
-## Project Context
-
-*(No stack information available - recommend running `/stack-scan` to generate technology profile)*
-
-{{/noStack}}
-{{#noRules}}
-*(No project-specific rules defined - consider using `/add-rule` to capture development standards)*
-
-{{/noRules}}
+*If either file is missing, call it out and suggest generating the relevant context.*
 
 ## Your Mission
 


### PR DESCRIPTION
## Summary
- reference project stack and rules files directly in planner and reviewer agents
- drop build-time detection of `.monkey` files, keeping only version metadata for templates
- clarify install logic comment about template data

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68bcde7700c08333b6bb0f3bfede53fb